### PR TITLE
Swift バージョンを 5.9 に変更

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
## 概要

Xcode のバージョンによっては Swift Package を導入できないので、Package.swift に記載する Swift バージョンを 5.9 に変更する。